### PR TITLE
Handles url escaped signatures

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -1107,7 +1107,10 @@ func (s *HMACSigner) Verify(message string, signature string) error {
 	}
 
 	if validSignature != signature {
-		return fmt.Errorf("signature did not match")
+		decodedSigniture, _ = url.QueryUnescape(signature)
+		if validSignature != decodedSigniture {
+			return fmt.Errorf("signature did not match")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Allows clients to encode their signatures before sending their request